### PR TITLE
Handle case where response XML is not parsed

### DIFF
--- a/layer/vector/KML.js
+++ b/layer/vector/KML.js
@@ -54,6 +54,10 @@ L.KML = L.FeatureGroup.extend({
 	},
 
 	_addKML: function(xml, options, url) {
+      if (!(xml instanceof XMLDocument)) {
+         this.fire("load-error");
+         return;
+      }
 		var layers = L.KML.parseKML(xml, url);
       if (!layers || !layers.length) {
          this.fire("load-error");


### PR DESCRIPTION
For certain KMLs, `XMLHttpRequeset.responseXML` will return `null` instead of an `XMLDocument`. In this case we now fire the `load-error` event and early out, whereas before an exception would be thrown when we attempted to call a method on a `null` value.

I'm not sure why the KML is not being parsed. I can successfully parse the KML using `new DOMParser().parseFromString(req.responseText, 'text/xml')`, so perhaps it has something to do with the mimetype. 